### PR TITLE
ZMNHOD1: Venetian blind support

### DIFF
--- a/app.json
+++ b/app.json
@@ -3185,10 +3185,23 @@
       "class": "windowcoverings",
       "capabilities": [
         "windowcoverings_state",
-        "dim",
+        "dim.shutter",
+        "dim.venetian",
         "measure_power",
         "measure_temperature"
       ],
+      "capabilitiesOptions": {
+        "dim.shutter": {
+            "title": {
+                "en": "Shutter position"
+            }
+        },
+        "dim.venetian": {
+            "title": {
+                "en": "Slats position"
+            }
+        }
+      },
       "mobile": {
         "components": [
           {
@@ -3200,7 +3213,13 @@
           {
             "id": "slider",
             "capabilities": [
-              "dim"
+              "dim.shutter"
+            ]
+          },
+          {
+            "id": "slider",
+            "capabilities": [
+              "dim.venetian"
             ]
           },
           {

--- a/app.json
+++ b/app.json
@@ -3185,7 +3185,6 @@
       "class": "windowcoverings",
       "capabilities": [
         "windowcoverings_state",
-        "onoff",
         "dim",
         "measure_power",
         "meter_power",
@@ -3197,12 +3196,6 @@
             "id": "ternary",
             "capabilities": [
               "windowcoverings_state"
-            ]
-          },
-          {
-            "id": "icon",
-            "capabilities": [
-              "onoff"
             ]
           },
           {

--- a/app.json
+++ b/app.json
@@ -3187,7 +3187,6 @@
         "windowcoverings_state",
         "dim",
         "measure_power",
-        "meter_power",
         "measure_temperature"
       ],
       "mobile": {
@@ -3208,7 +3207,6 @@
             "id": "sensor",
             "capabilities": [
               "measure_power",
-              "meter_power",
               "measure_temperature"
             ]
           }

--- a/app.json
+++ b/app.json
@@ -4716,6 +4716,54 @@
           }
         ]
       }
+    ],
+    "actions": [
+      {
+        "id": "shutter_position",
+        "title": {
+          "en": "Set to position"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=ZMNHOD1"
+          },
+          {
+            "type": "range",
+            "name": "value",
+            "min": 0,
+            "max": 100,
+            "step": 1,
+            "label": "%",
+            "labelMultiplier": 0,
+            "labelDecimals": 0
+          }
+        ]
+      },
+      {
+        "id": "slats_tilt",
+        "title": {
+          "en": "Tilt slats"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=ZMNHOD1"
+          },
+          {
+            "type": "range",
+            "name": "value",
+            "min": 0,
+            "max": 100,
+            "step": 1,
+            "label": "%",
+            "labelMultiplier": 0,
+            "labelDecimals": 0
+          }
+        ]
+      }
     ]
   }
 }

--- a/config/drivers/ZMNHOD1.json
+++ b/config/drivers/ZMNHOD1.json
@@ -29,10 +29,23 @@
 	"class": "windowcoverings",
 	"capabilities": [
 		"windowcoverings_state",
-		"dim",
+		"dim.shutter",
+		"dim.venetian",
 		"measure_power",
 		"measure_temperature"
 	],
+	"capabilitiesOptions": {
+		"dim.shutter": {
+			"title": {
+				"en": "Shutter position"
+			}
+		},
+		"dim.venetian": {
+			"title": {
+				"en": "Slats position"
+			}
+		}
+	},
 	"mobile": {
 		"components": [
 			{
@@ -44,7 +57,13 @@
 			{
 				"id": "slider",
 				"capabilities": [
-					"dim"
+					"dim.shutter"
+				]
+			},
+			{
+				"id": "slider",
+				"capabilities": [
+					"dim.venetian"
 				]
 			},
 			{

--- a/config/drivers/ZMNHOD1.json
+++ b/config/drivers/ZMNHOD1.json
@@ -29,7 +29,6 @@
 	"class": "windowcoverings",
 	"capabilities": [
 		"windowcoverings_state",
-		"onoff",
 		"dim",
 		"measure_power",
 		"meter_power",
@@ -41,12 +40,6 @@
 				"id": "ternary",
 				"capabilities": [
 					"windowcoverings_state"
-				]
-			},
-			{
-				"id": "icon",
-				"capabilities": [
-					"onoff"
 				]
 			},
 			{

--- a/config/drivers/ZMNHOD1.json
+++ b/config/drivers/ZMNHOD1.json
@@ -31,7 +31,6 @@
 		"windowcoverings_state",
 		"dim",
 		"measure_power",
-		"meter_power",
 		"measure_temperature"
 	],
 	"mobile": {
@@ -52,7 +51,6 @@
 				"id": "sensor",
 				"capabilities": [
 					"measure_power",
-					"meter_power",
 					"measure_temperature"
 				]
 			}

--- a/config/flow/actions/ZMNHOD1.json
+++ b/config/flow/actions/ZMNHOD1.json
@@ -1,0 +1,48 @@
+[
+	{
+		"id": "shutter_position",
+		"title": {
+			"en": "Set to position"
+		},
+		"args": [
+			{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=ZMNHOD1"
+			},
+			{
+				"type": "range",
+				"name": "value",
+				"min": 0,
+				"max": 100,
+				"step": 1,
+				"label": "%",
+				"labelMultiplier": 0,
+				"labelDecimals": 0
+			}
+		]
+	},
+	{
+		"id": "slats_tilt",
+		"title": {
+			"en": "Tilt slats"
+		},
+		"args": [
+			{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=ZMNHOD1"
+			},
+			{
+				"type": "range",
+				"name": "value",
+				"min": 0,
+				"max": 100,
+				"step": 1,
+				"label": "%",
+				"labelMultiplier": 0,
+				"labelDecimals": 0
+			}
+		]
+	}
+]

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -23,13 +23,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			},
 			command_report: 'SWITCH_BINARY_REPORT',
 			command_report_parser: (report, node) => {
-
-				// Save latest known position state
-				if (node && node.state) {
-					node.state.position = report['Value']
-				}
-
-				switch (report['Value']) {
+				switch (report.Value) {
 					case 'on/enable':
 						return 'up';
 					case 'off/disable':

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -12,17 +12,17 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			command_get: 'SWITCH_BINARY_GET',
 			command_set: 'SWITCH_BINARY_SET',
 			command_set_parser: (value, node) => {
-				switch(value) {
+				switch (value) {
 					case 'up':
-						return {'Switch Value': 'on/enable'};
+						return { 'Switch Value': 'on/enable' };
 					case 'down':
-						return {'Switch Value': 'off/disable'};
-					case 'idle':
-						windowcoveringStateStop(node);
-				};
+						return { 'Switch Value': 'off/disable' };
+					default:
+						windowcoveringStateStop(node.device_data);
+				}
 			},
 			command_report: 'SWITCH_BINARY_REPORT',
-			command_report_parser: (report, node) => {
+			command_report_parser: report => {
 				switch (report.Value) {
 					case 'on/enable':
 						return 'up';
@@ -40,8 +40,8 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			command_set_parser: value => {
 				if (value >= 1) value = 0.99;
 				return {
-					'Value': value * 100,
-					'Dimming Duration': 'Factory default'
+					Value: value * 100,
+					'Dimming Duration': 'Factory default',
 				};
 			},
 			command_report: 'SWITCH_MULTILEVEL_REPORT',
@@ -56,9 +56,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			command_get_parser: () => ({
 				Properties1: {
 					Scale: 2,
-					'Rate Type': 'Import'
+					'Rate Type': 'Import',
 				},
-				'Scale 2': 0
+				'Scale 2': 0,
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
@@ -147,18 +147,16 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		digital_temperature_sensor_reporting: {
 			index: 120,
 			size: 1,
-		}
-	}
+		},
+	},
 });
 
-function windowcoveringStateStop(node) {
-	Homey.wireless('zwave').getNode( node.device_data, function( err, node ) {
-		if( err ) return console.error( err );
-		node.CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_STOP_LEVEL_CHANGE({},
-			function( err, result ){
-				if( err ) return console.error( err );
-				module.exports.realtime( node.device_data, 'windowcoverings_state', 'idle' );
-			}
-		);
+function windowcoveringStateStop(DeviceData) {
+	Homey.wireless('zwave').getNode(DeviceData, (err, node) => {
+		if (err) return console.error(err);
+		node.CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_STOP_LEVEL_CHANGE({}, err => {
+			if (err) return console.error(err);
+			module.exports.realtime(node.device_data, 'windowcoverings_state', 'idle');
+		});
 	});
 }

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -8,6 +8,7 @@ const ZwaveDriver = require('homey-zwavedriver');
 module.exports = new ZwaveDriver(path.basename(__dirname), {
 	capabilities: {
 		windowcoverings_state: {
+			multiChannelNodeId: 1,
 			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
 			command_get: 'SWITCH_BINARY_GET',
 			command_set: 'SWITCH_BINARY_SET',
@@ -33,7 +34,8 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 			},
 		},
-		dim: {
+		'dim.shutter': {
+			multiChannelNodeId: 1,
 			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL',
 			command_get: 'SWITCH_MULTILEVEL_GET',
 			command_set: 'SWITCH_MULTILEVEL_SET',
@@ -50,7 +52,27 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				return null;
 			},
 		},
+		'dim.venetian': {
+			multiChannelNodeId: 2,
+			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL',
+			command_get: 'SWITCH_MULTILEVEL_GET',
+			command_set: 'SWITCH_MULTILEVEL_SET',
+			command_set_parser: value => {
+				if (value >= 1) value = 0.99;
+				return {
+					Value: value * 100,
+					'Dimming Duration': 'Factory default',
+				};
+			},
+			command_report: 'SWITCH_MULTILEVEL_REPORT',
+			command_report_parser: report => {
+				if (report && report['Value (Raw)']) return report['Value (Raw)'][0] / 100;
+				return null;
+			},
+			optional: true,
+		},
 		measure_power: {
+			multiChannelNodeId: 1,
 			command_class: 'COMMAND_CLASS_METER',
 			command_get: 'METER_GET',
 			command_get_parser: () => ({
@@ -71,6 +93,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			},
 		},
 		measure_temperature: {
+			multiChannelNodeId: 3,
 			command_class: 'COMMAND_CLASS_SENSOR_MULTILEVEL',
 			command_get: 'SENSOR_MULTILEVEL_GET',
 			command_get_parser: () => ({

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -55,36 +55,16 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			command_get: 'METER_GET',
 			command_get_parser: () => ({
 				Properties1: {
-					Scale: 7,
+					Scale: 2,
 					'Rate Type': 'Import'
 				},
-				'Scale 2': 1
+				'Scale 2': 0
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
 				if (report.hasOwnProperty('Properties2')
 					&& report.Properties2.hasOwnProperty('Scale bits 10')
 					&& report.Properties2['Scale bits 10'] === 2) {
-					return report['Meter Value (Parsed)'];
-				}
-				return null;
-			},
-		},
-		meter_power: {
-			command_class: 'COMMAND_CLASS_METER',
-			command_get: 'METER_GET',
-			command_get_parser: () => ({
-				Properties1: {
-					Scale: 0,
-					'Rate Type': 'Import'
-				},
-				'Scale 2': 1
-			}),
-			command_report: 'METER_REPORT',
-			command_report_parser: report => {
-				if (report.hasOwnProperty('Properties2')
-					&& report.Properties2.hasOwnProperty('Scale bits 10')
-					&& report.Properties2['Scale bits 10'] === 0) {
 					return report['Meter Value (Parsed)'];
 				}
 				return null;

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -38,7 +38,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 						return 'idle';
 				}
 			},
-			optional: true,
 		},
 		onoff: {
 			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
@@ -93,7 +92,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 				return null;
 			},
-			optional: true,
 		},
 		meter_power: {
 			command_class: 'COMMAND_CLASS_METER',
@@ -114,7 +112,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 				return null;
 			},
-			optional: true,
 		},
 		measure_temperature: {
 			command_class: 'COMMAND_CLASS_SENSOR_MULTILEVEL',

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -183,3 +183,33 @@ function windowcoveringStateStop(DeviceData) {
 		});
 	});
 }
+
+// trigger on action flows for custom dim.shutter capability
+Homey.manager('flow').on('action.shutter_position', (callback, args) => {
+	const value = {
+		Value: (args.value >= 100) ? 99 : args.value,
+		'Dimming Duration': 'Factory default',
+	};
+	Homey.wireless('zwave').getNode(args.device, (err, node) => {
+		node.MultiChannelNodes['1'].CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_SET(value, err => {
+			if (err) return console.error(err);
+		});
+	});
+	module.exports.realtime(args.device, 'dim.shutter', args.value / 100);
+	callback(null, true);
+});
+
+// trigger on action flows for custom dim.venetian capability
+Homey.manager('flow').on('action.slats_tilt', (callback, args) => {
+	const value = {
+		Value: (args.value >= 100) ? 99 : args.value,
+		'Dimming Duration': 'Factory default',
+	};
+	Homey.wireless('zwave').getNode(args.device, (err, node) => {
+		node.MultiChannelNodes['2'].CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_SET(value, err => {
+			if (err) return console.error(err);
+		});
+	});
+	module.exports.realtime(args.device, 'dim.venetian', args.value / 100);
+	callback(null, true);
+});

--- a/drivers/ZMNHOD1/driver.js
+++ b/drivers/ZMNHOD1/driver.js
@@ -33,23 +33,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 			},
 		},
-		onoff: {
-			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
-			command_get: 'SWITCH_BINARY_GET',
-			command_set: 'SWITCH_BINARY_SET',
-			command_set_parser: value => ({
-				'Switch Value': (value) ? 'on/enable' : 'off/disable',
-			}),
-			command_report: 'SWITCH_BINARY_REPORT',
-			command_report_parser: report => {
-				if (report['Value'] === 'on/enable') {
-					return true;
-				} else if (report['Value'] === 'off/disable') {
-					return false;
-				}
-				return null;
-			},
-		},
 		dim: {
 			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL',
 			command_get: 'SWITCH_MULTILEVEL_GET',


### PR DESCRIPTION
This is initial Venetian blind support for qubino dc shutter (parameter 71).
This pr works "fine" (fine as in it works) in case you have a Venetian blind but it introduce another dim slider in the mobile card even if the capability is not enabled. I have added issue  https://github.com/athombv/homey/issues/1296 to be able to work around this issue.

I have also added another issue https://github.com/athombv/homey/issues/1290 to be able to distinguish both sliders in the interface.

To work around both issues I have also added issue https://github.com/athombv/homey/issues/1288 to introduce the second slider as a child device/node. But this would not be my preferred solution as it add another card in the interface and the relation to the master device is too strong.  

I do have a question about using action flows and how to trigger cc commands. Is there a way I could call a capability in my zwave driver definition or should I use the zwave api directly as i have used it now?

cc @RobinBol 

PS this pr depends on #10 and #11