### PR TITLE
2 small bug fixes for the Qubino drivers

### DIFF
--- a/drivers/ZMNHDD1/driver.js
+++ b/drivers/ZMNHDD1/driver.js
@@ -117,7 +117,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			size: 1,
 		},
 		input_2_type: {
-			index: 1,
+			index: 2,
 			size: 1,
 		},
 		input_2_contact_type: {

--- a/drivers/ZMNHDD1/driver.js
+++ b/drivers/ZMNHDD1/driver.js
@@ -166,7 +166,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		},
 		dimming_time_when_key_pressed: {
 			index: 66,
-			size: 1,
+			size: 2,
 		},
 	},
 });

--- a/drivers/ZMNHSD1/driver.js
+++ b/drivers/ZMNHSD1/driver.js
@@ -162,7 +162,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		},
 		dimming_time_when_key_pressed: {
 			index: 66,
-			size: 1,
+			size: 2,
 		},
 	},
 });

--- a/drivers/ZMNHVD1/driver.js
+++ b/drivers/ZMNHVD1/driver.js
@@ -106,7 +106,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		},
 		dimming_time_when_key_pressed: {
 			index: 66,
-			size: 1,
+			size: 2,
 		},
 		temperature_sensor_offset: {
 			index: 110,


### PR DESCRIPTION
Dear Athom,

I've created 2 small bugfixes;
- Corrected the parameter size of "dimming time" parameter (id 66) to size 2 (based on the manuals of the different devices), because currently the setting is not working for these devices.
- Corrected the input_type ID for the ZMNHDD1 driver, it had two parameter settings for ID 1.