### PR TITLE
Fix size of soft on/off

### DIFF
--- a/drivers/ZMNHDD1/driver.js
+++ b/drivers/ZMNHDD1/driver.js
@@ -163,7 +163,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		},
 		dimming_time_soft_on_off: {
 			index: 65,
-			size: 1,
+			size: 2,
 		},
 		dimming_time_when_key_pressed: {
 			index: 66,


### PR DESCRIPTION
Parameter no. 65 – Dimming time (soft on/off)
Set value means time of moving the Dimmer between min. and max. dimming values by short press of push button I1 or controlled through UI (BasicSet). Available configuration parameters (data type is 2 Byte DEC):