### PR TITLE
Fixed naming of first relay.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1032,8 +1032,8 @@
             ],
             "icon": "/drivers/ZMNHBD1/assets/icon.svg",
             "name": {
-              "en": "ZMNHBD1 Relay 2",
-              "nl": "ZMNHBD1 Relais 2"
+              "en": "ZMNHBD1 Relay 1",
+              "nl": "ZMNHBD1 Relais 1"
             },
             "mobile": {
               "components": [

--- a/config/drivers/ZMNHBD1.json
+++ b/config/drivers/ZMNHBD1.json
@@ -57,8 +57,8 @@
 				],
 				"icon": "/drivers/ZMNHBD1/assets/icon.svg",
 				"name": {
-					"en": "ZMNHBD1 Relay 2",
-					"nl": "ZMNHBD1 Relais 2"
+					"en": "ZMNHBD1 Relay 1",
+					"nl": "ZMNHBD1 Relais 1"
 				},
 				"mobile": {
 					"components": [


### PR DESCRIPTION
Both relays for ZMNHBD1 was named "ZMNHBD1 Relay 2", fixed first one to be named "ZMNHBD1 Relay 1".