### PR TITLE
Requested fixes for ZMNKAD

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -4,7 +4,7 @@
     "en": "Qubino"
   },
   "sdk": 2,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "compatibility": ">=4.0.0",
   "brandColor": "#1784c7",
   "description": {

--- a/.homeycompose/drivers/flow/triggers/alarmTurnedOff.json
+++ b/.homeycompose/drivers/flow/triggers/alarmTurnedOff.json
@@ -1,7 +1,7 @@
 {
   "$id": "alarmTurnedOff_{{driverId}}",
   "title": {
-    "en": "The alarm turned off",
-    "nl": "Het alarm ging uit"
+    "en": "Alarm mode turned off",
+    "nl": "Alarm toestand uitgezet"
   }
 }

--- a/.homeycompose/drivers/flow/triggers/alarmTurnedOn.json
+++ b/.homeycompose/drivers/flow/triggers/alarmTurnedOn.json
@@ -1,7 +1,7 @@
 {
   "$id": "alarmTurnedOn_{{driverId}}",
   "title": {
-    "en": "The alarm turned on",
-    "nl": "Het alarm gaat aan"
+    "en": "Alarm mode turned off",
+    "nl": "Alarm toestand uitgezet"
   }
 }

--- a/.homeycompose/flow/triggers/alarmTurnedOn.json
+++ b/.homeycompose/flow/triggers/alarmTurnedOn.json
@@ -5,13 +5,13 @@
     "nl": "Alarm toestand aangezet"
   },
   "args": [
-      {
-        "name": "device",
-        "type": "device",
-        "filter": {
-          "driver_id": "ZMNKAD",
-          "flags": "zwaveRoot"
-        }
+    {
+      "name": "device",
+      "type": "device",
+      "filter": {
+        "driver_id": "ZMNKAD",
+        "flags": "zwaveRoot"
       }
-    ]
+    }
+  ]
 }

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "en": "Qubino"
   },
   "sdk": 2,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "compatibility": ">=4.0.0",
   "brandColor": "#1784c7",
   "description": {
@@ -1227,8 +1227,8 @@
       {
         "id": "alarmTurnedOn_ZMNHQD",
         "title": {
-          "en": "The alarm turned on",
-          "nl": "Het alarm gaat aan"
+          "en": "Alarm mode turned off",
+          "nl": "Alarm toestand uitgezet"
         },
         "args": [
           {
@@ -1241,8 +1241,8 @@
       {
         "id": "alarmTurnedOff_ZMNHQD",
         "title": {
-          "en": "The alarm turned off",
-          "nl": "Het alarm ging uit"
+          "en": "Alarm mode turned off",
+          "nl": "Alarm toestand uitgezet"
         },
         "args": [
           {
@@ -10475,6 +10475,10 @@
             "index": 11,
             "size": 2
           },
+          "hint": {
+            "en": "This parameter (11) defines the time (>30 seconds) after which the device is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
+            "nl": "Deze parameter (11) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch uitzet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
+          },
           "id": "autoOff",
           "type": "number",
           "label": {
@@ -10489,16 +10493,16 @@
           "units": {
             "en": "s",
             "nl": "s"
-          },
-          "hint": {
-            "en": "This parameter (11) defines the time after which the device is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
-            "nl": "Deze parameter (11) bepaalt de tijd waarna het apparaat zichzelf automatisch uitzet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
           }
         },
         {
           "zwave": {
             "index": 10,
             "size": 2
+          },
+          "hint": {
+            "en": "This parameter (10) defines the time (>30 seconds) after which the device is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
+            "nl": "Deze parameter (10) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch aanzet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
           },
           "id": "autoOn",
           "type": "number",
@@ -10514,10 +10518,6 @@
           "attr": {
             "min": 0,
             "max": 32535
-          },
-          "hint": {
-            "en": "This parameter (10) defines the time after which the device is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
-            "nl": "Deze parameter (10) bepaalt de tijd waarna het apparaat zichzelf automatisch aanzet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
           }
         },
         {
@@ -13553,6 +13553,10 @@
             "index": 11,
             "size": 2
           },
+          "hint": {
+            "en": "This parameter (11) defines the time (>30 seconds) after which the device is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
+            "nl": "Deze parameter (11) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch uitzet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
+          },
           "id": "autoOff",
           "type": "number",
           "label": {
@@ -13567,16 +13571,16 @@
           "units": {
             "en": "s",
             "nl": "s"
-          },
-          "hint": {
-            "en": "This parameter (11) defines the time after which the device is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
-            "nl": "Deze parameter (11) bepaalt de tijd waarna het apparaat zichzelf automatisch uitzet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
           }
         },
         {
           "zwave": {
             "index": 10,
             "size": 2
+          },
+          "hint": {
+            "en": "This parameter (10) defines the time (>30 seconds) after which the device is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
+            "nl": "Deze parameter (10) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch aanzet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
           },
           "id": "autoOn",
           "type": "number",
@@ -13592,16 +13596,16 @@
           "attr": {
             "min": 0,
             "max": 32535
-          },
-          "hint": {
-            "en": "This parameter (10) defines the time after which the device is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
-            "nl": "Deze parameter (10) bepaalt de tijd waarna het apparaat zichzelf automatisch aanzet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
           }
         },
         {
           "zwave": {
             "index": 13,
             "size": 2
+          },
+          "hint": {
+            "en": "This parameter (13) defines the time (>30 seconds) after which output 1 is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
+            "nl": "Deze parameter (13) bepaalt de tijd (>30 seconden) waarna uitgang 1 automatisch wordt uitgezet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
           },
           "id": "autoOffQ1",
           "type": "number",
@@ -13617,10 +13621,6 @@
           "units": {
             "en": "s",
             "nl": "s"
-          },
-          "hint": {
-            "en": "This parameter (13) defines the time after which output 1 is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
-            "nl": "Deze parameter (13) bepaalt de tijd waarna uitgang 1 automatisch wordt uitgezet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
           }
         },
         {
@@ -13633,6 +13633,10 @@
             "min": 0,
             "max": 32535
           },
+          "hint": {
+            "en": "This parameter (12) defines the time (>30 seconds) after which output 1 is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
+            "nl": "Deze parameter (12) bepaalt de tijd (>30 seconden) waarna uitgang 1 automatisch wordt aangezet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
+          },
           "id": "autoOnQ1",
           "type": "number",
           "label": {
@@ -13642,10 +13646,6 @@
           "units": {
             "en": "s",
             "nl": "s"
-          },
-          "hint": {
-            "en": "This parameter (12) defines the time after which output 1 is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
-            "nl": "Deze parameter (12) bepaalt de tijd waarna uitgang 1 automatisch wordt aangezet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
           }
         },
         {

--- a/drivers/ZMNHQD/driver.settings.compose.json
+++ b/drivers/ZMNHQD/driver.settings.compose.json
@@ -4,6 +4,10 @@
     "zwave": {
       "index": 11,
       "size": 2
+    },
+    "hint": {
+      "en": "This parameter ({{zwaveParameterIndex}}) defines the time (>30 seconds) after which the device is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
+      "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch uitzet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
     }
   },
   {
@@ -11,6 +15,10 @@
     "zwave": {
       "index": 10,
       "size": 2
+    },
+    "hint": {
+      "en": "This parameter ({{zwaveParameterIndex}}) defines the time (>30 seconds) after which the device is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
+      "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch aanzet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
     }
   },
   {

--- a/drivers/ZMNKAD/driver.settings.compose.json
+++ b/drivers/ZMNKAD/driver.settings.compose.json
@@ -4,6 +4,10 @@
     "zwave": {
       "index": 11,
       "size": 2
+    },
+    "hint": {
+      "en": "This parameter ({{zwaveParameterIndex}}) defines the time (>30 seconds) after which the device is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
+      "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch uitzet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
     }
   },
   {
@@ -11,6 +15,10 @@
     "zwave": {
       "index": 10,
       "size": 2
+    },
+    "hint": {
+      "en": "This parameter ({{zwaveParameterIndex}}) defines the time (>30 seconds) after which the device is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
+      "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de tijd (>30 seconden) waarna het apparaat zichzelf automatisch aanzet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
     }
   },
   {
@@ -18,6 +26,10 @@
     "zwave": {
       "index": 13,
       "size": 2
+    },
+    "hint": {
+      "en": "This parameter ({{zwaveParameterIndex}}) defines the time (>30 seconds) after which output 1 is turned off automatically. Note: setting this parameter to zero will disable automatically turning off.",
+      "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de tijd (>30 seconden) waarna uitgang 1 automatisch wordt uitgezet. Let op: het instellen van deze parameter op nul schakelt het automatisch uit gaan uit."
     }
   },
   {
@@ -30,6 +42,10 @@
     "attr": {
       "min": 0,
       "max": 32535
+    },
+    "hint": {
+      "en": "This parameter ({{zwaveParameterIndex}}) defines the time (>30 seconds) after which output 1 is turned on automatically. Note: setting this parameter to zero will disable automatically turning on.",
+      "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de tijd (>30 seconden) waarna uitgang 1 automatisch wordt aangezet. Let op: het instellen van deze parameter op nul schakelt het automatisch aan gaan uit."
     }
   },
   {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -117,6 +117,8 @@ module.exports = {
     AUTO_OFF: 'autoOff',
     AUTO_OFF_Q1: 'autoOffQ1',
     AUTO_OFF_Q2: 'autoOffQ2',
+    AUTO_ON: 'autoOn',
+    AUTO_ON_Q1: 'autoOnQ1',
     ANTIFREEZE: 'antifreeze',
     PID_DEADBAND: 'pidDeadband',
     WORKING_MODE: 'workingMode',

--- a/node_modules/homey-meshdriver/package.json
+++ b/node_modules/homey-meshdriver/package.json
@@ -22,7 +22,7 @@
   "_resolved": "https://registry.npmjs.org/homey-meshdriver/-/homey-meshdriver-1.3.24.tgz",
   "_shasum": "fda460171092f71c046dd9d0c8662c9611c280c6",
   "_spec": "homey-meshdriver@^1.3.24",
-  "_where": "/Volumes/Data/HOMEY/PROJECTS/QUBINO/com.qubino",
+  "_where": "/Volumes/Data HD/HOMEY/PROJECTS/QUBINO/com.qubino",
   "author": {
     "name": "Athom B.V."
   },


### PR DESCRIPTION
Fixing the requested "bugs" as reported by Merel:

> 1. When the Luxy light is set to white (no color) the Flow card “Set hue” is not working, the light is not responding to the set hue value.
Correct behavior for HSV values; white light with Saturation of 0 will not change with setting the Hue; white remains white

> 2. The hint text for Parameter 10 "Turn on/off automatically" is confusing “minimum value 0 and max 32535”. Because entering a value between 0 and 30 will not do anything. The parameter can only be set to 0 to turn it off, and has a minimum value of 30 and max 32535.  I believe the same is true for parameter 13, "Turn off/on output 1 automatically”. 
Added the additional comment in the hint. Can't change the range displayed (auto generated) and can't add a solution in the driver that will also update the UI (not possible with Homey)

> 3. The Luxy Smart Switch Relay also contains settings such as “Turn on/off automatically” and “Turn on/off output 1 automatically” this is double, seeing that these settings are already in the Switch itself. Entering any values for the Switch Relay, results in an error   when saving the settings. See attachment. The only setting that is not double is “Energy, Always On”, however this can be set without an erro appearing. 
Long lasting issue, can't be solved from app space, will require fix in Homey

